### PR TITLE
feat: allow scripts access to all node standard objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,11 +125,18 @@ class Scriptable {
       return m;
     };
 
+    const globalProperties = Object.fromEntries(
+      Object.getOwnPropertyNames(global).map(
+        key => [key, global[key]],
+      ),
+    );
+    delete globalProperties.globalThis;
+    delete globalProperties.global;
+
     const sandbox = {
+      ...globalProperties,
       module: buildModule(),
       require: id => sandbox.module.require(id),
-      console,
-      process,
       serverless: this.serverless,
       options: this.options,
       __filename: scriptFile,

--- a/index.js
+++ b/index.js
@@ -141,6 +141,7 @@ class Scriptable {
       options: this.options,
       __filename: scriptFile,
       __dirname: path.dirname(fs.realpathSync(scriptFile)),
+      exports: Object(),
     };
 
     // See: https://github.com/nodejs/node/blob/7c452845b8d44287f5db96a7f19e7d395e1899ab/lib/internal/modules/cjs/helpers.js#L14

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -146,9 +146,24 @@ describe('ScriptablePluginTest', () => {
       .then(() => expect(serverless.service.artifact).equal(`hello${moduleName}`));
   });
 
-  it('should able use default classes from node in javascript', () => {
+  it('should able to use default classes from node in javascript', () => {
     const scriptFile = tmp.fileSync({ postfix: '.js' });
     fs.writeFileSync(scriptFile.name, 'new URL("http://localhost"); serverless.service.artifact = "test.zip";');
+
+    const serverless = serviceWithScripts({ test: scriptFile.name });
+    const scriptable = new Scriptable(serverless);
+
+    return runScript(scriptable, 'test')
+      .then(() => expect(serverless.service.artifact).equal('test.zip'));
+  });
+
+  it('should able to use exports object in javascript', () => {
+    const scriptFile = tmp.fileSync({ postfix: '.js' });
+    fs.writeFileSync(
+      scriptFile.name,
+      `Object.defineProperty(exports, "__esModule", { value: true });
+      serverless.service.artifact = "test.zip";`,
+    );
 
     const serverless = serviceWithScripts({ test: scriptFile.name });
     const scriptable = new Scriptable(serverless);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -146,6 +146,17 @@ describe('ScriptablePluginTest', () => {
       .then(() => expect(serverless.service.artifact).equal(`hello${moduleName}`));
   });
 
+  it('should able use default classes from node in javascript', () => {
+    const scriptFile = tmp.fileSync({ postfix: '.js' });
+    fs.writeFileSync(scriptFile.name, 'new URL("http://localhost"); serverless.service.artifact = "test.zip";');
+
+    const serverless = serviceWithScripts({ test: scriptFile.name });
+    const scriptable = new Scriptable(serverless);
+
+    return runScript(scriptable, 'test')
+      .then(() => expect(serverless.service.artifact).equal('test.zip'));
+  });
+
   it('should wait for async method to be finished', () => {
     const scriptFile = tmp.fileSync({ postfix: '.js' });
     const script = 'require("bluebird").delay(100).then(() => serverless.service.artifact = "test.zip")';


### PR DESCRIPTION
If you have a `.js` scripts that uses one of the standard available classes, you'll get a ReferenceError, since the `global` and `globalThis` object doesn't have these classes in them.

Something like this in a script won't work:
```
new URL("http://localhost");
```
This is a problem with many libraries. For example we have a script that needs to retrieve a secrets from the AWS SecretsManager, but is unable to do so, since it relies on `URL` to be available globally.

This PR fixes that by giving all global objects to the execution context of the script. I'm not sure if there're any security implications to consider for this. In theory it's possible that global classes could be modified by the script that is running, causing problems in the serverless execution environment. But I guess only trusted code should be run, so I don't consider this as a problem.