### PR TITLE
Support for `provider.environment` in `serverless.yml`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@ root: true
 extends: airbnb-base
 
 parserOptions:
-  ecmaVersion: 2019
+  ecmaVersion: 2020
 
 rules:
   class-methods-use-this: off

--- a/index.js
+++ b/index.js
@@ -111,16 +111,21 @@ class Scriptable {
     };
   }
 
+  environment() {
+    return {
+      ...(process.env || {}),
+      ...((((this.serverless || {}).service || {}).provider || {}).environment || {}),
+    };
+  }
+
   runCommand(script) {
     if (this.showCommands) {
       console.log(`Running command: ${script}`);
     }
 
-    console.log(`Provider environment: ${JSON.stringify(this.serverless.service.provider.environment)}`);
-
     try {
       return execSync(script, {
-        env: { ...process.env, ...this.serverless.service.provider.environment },
+        env: this.environment(),
         stdio: [this.stdin, this.stdout, this.stderr],
       });
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ class Scriptable {
   environment() {
     return {
       ...(process.env || {}),
-      ...((((this.serverless || {}).service || {}).provider || {}).environment || {}),
+      ...(this.serverless?.service?.provider?.environment || {}),
     };
   }
 

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ class Scriptable {
       console.log(`Running command: ${script}`);
     }
 
-    console.log(`Provider environment: ${this.serverless.service.provider.environment}`);
+    console.log(`Provider environment: ${JSON.stringify(this.serverless.service.provider.environment)}`);
 
     try {
       return execSync(script, {

--- a/index.js
+++ b/index.js
@@ -116,8 +116,13 @@ class Scriptable {
       console.log(`Running command: ${script}`);
     }
 
+    console.log(`Provider environment: ${this.serverless.provider.environment}`);
+
     try {
-      return execSync(script, { stdio: [this.stdin, this.stdout, this.stderr] });
+      return execSync(script, {
+        env: { ...process.env, ...this.serverless.provider.environment },
+        stdio: [this.stdin, this.stdout, this.stderr],
+      });
     } catch (err) {
       throw new SimpleError(`Failed to run command: ${script}`);
     }

--- a/index.js
+++ b/index.js
@@ -164,6 +164,9 @@ class Scriptable {
       __filename: scriptFile,
       __dirname: path.dirname(fs.realpathSync(scriptFile)),
       exports: Object(),
+      process: {
+        env: this.environment(),
+      },
     };
 
     // See: https://github.com/nodejs/node/blob/7c452845b8d44287f5db96a7f19e7d395e1899ab/lib/internal/modules/cjs/helpers.js#L14

--- a/index.js
+++ b/index.js
@@ -116,11 +116,11 @@ class Scriptable {
       console.log(`Running command: ${script}`);
     }
 
-    console.log(`Provider environment: ${this.serverless.provider.environment}`);
+    console.log(`Provider environment: ${this.serverless.service.provider.environment}`);
 
     try {
       return execSync(script, {
-        env: { ...process.env, ...this.serverless.provider.environment },
+        env: { ...process.env, ...this.serverless.service.provider.environment },
         stdio: [this.stdin, this.stdout, this.stderr],
       });
     } catch (err) {


### PR DESCRIPTION
I noticed that `provider.environment: {}` wasn't being pushed down to scripts.

This PR will allow scripts to utilize environment variables defined in `provider.environment`. 